### PR TITLE
Migrate Edraak viewport customizations with tests

### DIFF
--- a/common/djangoapps/edraak_tests/tests/test_arabic_mathjax.py
+++ b/common/djangoapps/edraak_tests/tests/test_arabic_mathjax.py
@@ -2,7 +2,6 @@
 Tests for the Arabic MathJax extension setup.
 """
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from edxmako.shortcuts import render_to_string
 from mock import patch
 import requests

--- a/common/djangoapps/edraak_tests/tests/test_viewport_meta.py
+++ b/common/djangoapps/edraak_tests/tests/test_viewport_meta.py
@@ -1,0 +1,58 @@
+import ddt
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from edxmako import lookup_template
+from mock import patch
+from unittest import skipUnless
+
+from courseware.testutils import RenderXBlockTestMixin
+from util.url import reload_django_url_config
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+
+from edraak_tests.tests.helpers import ModuleStoreTestCaseLoggedIn
+
+
+@ddt.ddt
+@skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class ViewportMetaTestCase(TestCase):
+    """
+    Tests the Edraak's viewport configs.
+    """
+    def test_defaults(self):
+        """
+        Testing the default settings for the feature flags.
+        """
+        self.assertTrue(settings.FEATURES['EDRAAK_VIEWPORT_CHANGES'])
+
+    def test_edraak_desktop_viewport_config(self):
+        """
+        Use Edraak's QA recommendation by removing the viewport form `main.html`.
+        """
+        res = self.client.get('/login')
+        self.assertNotContains(res, 'name="viewport"')
+
+    @patch.dict(settings.FEATURES, EDRAAK_VIEWPORT_CHANGES=False)
+    def test_edx_desktop_viewport_config(self):
+        """
+        Disable the Edraak customization and revert to edX's default.
+        """
+        res = self.client.get('/login')
+        self.assertContains(res, 'name="viewport"')
+
+    @ddt.data(
+        'EDRAAK_VIEWPORT_CHANGES',  # The feature flag should be used
+        'name="viewport"',  # The viewport should be applied when the feature flag is used
+        'chromeless-wrapper',  # The Edraak custom class should be used
+    )
+    def test_edraak_chromless_config(self, needed_string):
+        """
+        Use Edraak's QA recommendation by re-enabling the viewport for iPhone on chromeless.
+
+        Testing this template is a bit harder than it seems.
+        So instead we're checking the template code itself.
+        """
+        template = settings.PROJECT_ROOT / 'templates/courseware/courseware-chromeless.html'
+        template_code = template.text()
+
+        self.assertIn(needed_string, template_code)

--- a/lms/djangoapps/edraak_lms_tests/__init__.py
+++ b/lms/djangoapps/edraak_lms_tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+A module for adding lms-wide tests for Edraak.
+"""

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -102,6 +102,9 @@ FEATURES = {
 
     'DISABLE_LOGIN_BUTTON': False,  # used in systems where login is automatic, eg MIT SSL
 
+    # The recommendation by our QA is to turn this on until edX provide proper support for mobile.
+    'EDRAAK_VIEWPORT_CHANGES': True,
+
     # extrernal access methods
     'AUTH_USE_OPENID': False,
     'AUTH_USE_CERTIFICATES': False,

--- a/lms/static/sass/course/courseware/_courseware.scss
+++ b/lms/static/sass/course/courseware/_courseware.scss
@@ -103,6 +103,16 @@ html.video-fullscreen {
 .course-wrapper {
   position: relative;
 
+  &.chromeless-wrapper {
+    section.course-content {
+      @include direction();
+
+      background-color: #fafafa;
+      position: absolute;
+      width: 100%;
+    }
+  }
+
   .courseware-results-wrapper {
     display: none;
   }

--- a/lms/templates/courseware/courseware-chromeless.html
+++ b/lms/templates/courseware/courseware-chromeless.html
@@ -2,6 +2,7 @@
 <%inherit file="/main.html" />
 <%namespace name='static' file='/static_content.html'/>
 <%!
+from django.conf import settings
 from django.utils.translation import ugettext as _
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 
@@ -33,6 +34,10 @@ ${static.get_page_title_breadcrumbs(course_name())}
 </%block>
 
 <%block name="headextra">
+% if settings.FEATURES['EDRAAK_VIEWPORT_CHANGES']:
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+% endif
+
 <%static:css group='style-course-vendor'/>
 <%static:css group='style-course'/>
 ## Utility: Notes
@@ -69,7 +74,7 @@ ${HTML(fragment.foot_html())}
 
 </%block>
 
-<div class="course-wrapper">
+<div class="course-wrapper chromeless-wrapper">
   <section class="course-content" id="course-content">
     ${HTML(fragment.body_html())}
   </section>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -26,7 +26,10 @@ from pipeline_mako import render_require_js_path_overrides
 <head dir="${static.dir_rtl()}">
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    % if not settings.FEATURES['EDRAAK_VIEWPORT_CHANGES']:
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    % endif
 
 ## Define a couple of helper functions to make life easier when
 ## embedding theme conditionals into templates. All inheriting


### PR DESCRIPTION
### Description

TASK: [Fix webviews width for for normal and chromless browsers](https://app.asana.com/0/256944342521670/379587353715603)

Updated `viewport` according to @Edraak/quality-assurance feedback in Dogwood. During the migration I made `viewport` updates guarded by the feature flag `EDRAAK_VIEWPORT_CHANGES` and added tests.

### Testing
- [x] Rename feature to have `EDRAAK_` prefix!
- [ ] Test on mobile
- [ ] Test on iPhone app

### Related PRs
- https://github.com/Edraak/edx-platform/pull/287
- https://github.com/Edraak/edx-platform/pull/204
