### PR TITLE
Use platform_name instead of site_name in password reset email (OSPR Dup)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -278,4 +278,5 @@ Casey Litton <caseylitton@gmail.com>
 Jhony Avella <jhony.avella@edunext.co>
 Tanmay Mohapatra <tanmaykm@gmail.com>
 Brian Mesick <bmesick@edx.org>
+Salah Alomari <salomari@qrf.org>
 Jeff LaJoie <jlajoie@edx.org>

--- a/common/djangoapps/student/forms.py
+++ b/common/djangoapps/student/forms.py
@@ -49,7 +49,7 @@ class PasswordResetFormNoActive(PasswordResetForm):
     def save(
             self,
             domain_override=None,
-            subject_template_name='registration/password_reset_subject.txt',
+            subject_template_name='emails/password_reset_subject.txt',
             email_template_name='registration/password_reset_email.html',
             use_https=False,
             token_generator=default_token_generator,

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -304,3 +304,21 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         self.assertEquals(confirm_kwargs['extra_context']['platform_name'], 'Fake University')
         self.user = User.objects.get(pk=self.user.pk)
         self.assertTrue(self.user.is_active)
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', "Test only valid in LMS")
+    @patch('django.core.mail.send_mail')
+    @ddt.data('Crazy Awesome Site', 'edX')
+    def test_reset_password_email_subject(self, platform_name, send_email):
+        """
+        Tests that the right platform name is included in
+        the reset password email subject
+        """
+        with patch("django.conf.settings.PLATFORM_NAME", platform_name):
+            req = self.request_factory.post(
+                '/password_reset/', {'email': self.user.email}
+            )
+            req.user = self.user
+            password_reset(req)
+            subj, _, _, _ = send_email.call_args[0]
+
+            self.assertIn(platform_name, subj)

--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -188,18 +188,22 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
             req = self.request_factory.post(
                 '/password_reset/', {'email': self.user.email}
             )
+            req.is_secure = Mock(return_value=True)
             req.get_host = Mock(return_value=domain_override)
             req.user = self.user
             password_reset(req)
             _, msg, _, _ = send_email.call_args[0]
 
-            reset_msg = "you requested a password reset for your user account at {}"
-            if domain_override:
-                reset_msg = reset_msg.format(domain_override)
-            else:
-                reset_msg = reset_msg.format(settings.SITE_NAME)
+            reset_intro_msg = "you requested a password reset for your user account at {}".format(platform_name)
+            self.assertIn(reset_intro_msg, msg)
 
-            self.assertIn(reset_msg, msg)
+            reset_link = "https://{}/"
+            if domain_override:
+                reset_link = reset_link.format(domain_override)
+            else:
+                reset_link = reset_link.format(settings.SITE_NAME)
+
+            self.assertIn(reset_link, msg)
 
             sign_off = "The {} Team".format(platform_name)
             self.assertIn(sign_off, msg)
@@ -224,7 +228,7 @@ class ResetPasswordTests(EventTestMixin, CacheIsolationTestCase):
         password_reset(req)
         _, msg, from_addr, _ = send_email.call_args[0]
 
-        reset_msg = "you requested a password reset for your user account at openedx.localhost"
+        reset_msg = "you requested a password reset for your user account at {}".format(fake_get_value('platform_name'))
 
         self.assertIn(reset_msg, msg)
 

--- a/lms/templates/emails/password_reset_subject.txt
+++ b/lms/templates/emails/password_reset_subject.txt
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% autoescape off %}
+{% blocktrans %}Password reset on {{ platform_name }}{% endblocktrans %}
+{% endautoescape %}

--- a/lms/templates/registration/password_reset_email.html
+++ b/lms/templates/registration/password_reset_email.html
@@ -1,5 +1,5 @@
 {% load i18n %}{% load url from future %}{% autoescape off %}
-{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+{% blocktrans %}You're receiving this e-mail because you requested a password reset for your user account at {{ platform_name }}.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}


### PR DESCRIPTION
Duplicates: [Use platform_name instead of site_name in password reset email](https://github.com/edx/edx-platform/pull/14845).