### PR TITLE
Set the default course mode to `honor` for Edraak

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -6,6 +6,7 @@ import pytz
 
 from collections import namedtuple, defaultdict
 from config_models.models import ConfigurationModel
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
@@ -140,6 +141,8 @@ class CourseMode(models.Model):
     # use "honor"
     DEFAULT_SHOPPINGCART_MODE_SLUG = HONOR
     DEFAULT_SHOPPINGCART_MODE = Mode(HONOR, _('Honor'), 0, '', 'usd', None, None, None, None)
+
+    EDRAAK_DEFAULT_MODE = DEFAULT_SHOPPINGCART_MODE
 
     class Meta(object):
         unique_together = ('course_id', 'mode_slug', 'currency')
@@ -306,7 +309,10 @@ class CourseMode(models.Model):
 
         modes = ([mode.to_tuple() for mode in found_course_modes])
         if not modes:
-            modes = [cls.DEFAULT_MODE]
+            if settings.FEATURES.get('EDRAAK_DEFAULT_MODE_HONOR'):
+                return [cls.EDRAAK_DEFAULT_MODE]
+
+            return [cls.DEFAULT_MODE]
 
         return modes
 


### PR DESCRIPTION
Task: [Marketing site: A "server Error" page is being displayed when trying to Enrol in a course.](https://app.asana.com/0/256944342521670/428239735963847).

### Related PRs
 - Configuration PR: https://github.com/Edraak/configuration-secure/pull/5
 - Dogwood PR: https://github.com/Edraak/edx-platform/pull/178.

**Hint:** this requires the feature flag `EDRAAK_DEFAULT_MODE_HONOR=True` for it to work.