### PR TITLE
Course enroll success page redirect to marketing site

### DIFF
--- a/common/djangoapps/course_modes/edraak_helpers.py
+++ b/common/djangoapps/course_modes/edraak_helpers.py
@@ -1,0 +1,49 @@
+""" Edraak custom helper methods for CourseModes. """
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from edxmako.shortcuts import marketing_link
+
+
+def is_marketing_course_success_page_enabled():
+    """
+    Checks if the feature is enabled, while making some sanity checks along the way!
+    """
+    if not settings.FEATURES.get('EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE'):
+        return False
+
+    base_message = 'You have enabled the `EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE` feature'
+
+    if not settings.FEATURES.get('ENABLE_MKTG_SITE'):
+        raise Exception('{base} {other}'.format(
+            base=base_message,
+            other='without enabling the marketing site. Please enable the latter with the '
+                  '`ENABLE_MKTG_SITE` feature flag.',
+        ))
+
+    mktg_urls_message = '{base} {other}'.format(
+        base=base_message,
+        other='but did not configure either COURSE_SUCCESS_PAGE_FORMAT or ROOT in the MKTG_URLS.',
+    )
+
+    try:
+        if not settings.MKTG_URLS['ROOT'] or not settings.MKTG_URLS['COURSE_SUCCESS_PAGE_FORMAT']:
+            raise Exception(mktg_urls_message)
+    except KeyError:
+        raise Exception(mktg_urls_message)
+
+    if '{course_id}' not in settings.MKTG_URLS['COURSE_SUCCESS_PAGE_FORMAT']:
+        raise Exception('{base} {other}'.format(
+            base=base_message,
+            other='but COURSE_SUCCESS_PAGE_FORMAT does not contain the formatting argument `course_id`.',
+        ))
+
+    return True
+
+
+def get_course_success_page_url(course_id):
+    if is_marketing_course_success_page_enabled():
+        marketing_root_format = marketing_link('COURSE_SUCCESS_PAGE_FORMAT')
+        return marketing_root_format.format(course_id=course_id)
+    else:
+        return reverse('dashboard')

--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -1,4 +1,5 @@
 """ Helper methods for CourseModes. """
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from course_modes.models import CourseMode

--- a/common/djangoapps/course_modes/tests/test_edraak_helpers.py
+++ b/common/djangoapps/course_modes/tests/test_edraak_helpers.py
@@ -1,0 +1,76 @@
+"""
+A test suite for Edraak's customization on the Courses Modes
+"""
+import unittest
+
+import ddt
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from mock import patch
+
+from course_modes import edraak_helpers
+
+
+@ddt.ddt
+@unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+class HelpersTestCase(ModuleStoreTestCase):
+    def test_default_settings(self):
+        """
+        Ensure that edX tests passes.
+        """
+        self.assertFalse(settings.FEATURES.get('EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE'),
+                         msg='The feature should be off by default, even during testing.')
+
+    def test_feature_by_default_helper(self):
+        """
+        Also test the URL helper.
+        """
+        self.assertFalse(edraak_helpers.is_marketing_course_success_page_enabled(), 'Should be disabled by default')
+        self.assertEqual(edraak_helpers.get_course_success_page_url('a/b/c'), reverse('dashboard'))
+
+    @ddt.unpack
+    @ddt.data(
+        {
+            # Reason: Marketing site is disabled
+            'mktg_urls': {'ROOT': 'https://omar', 'COURSE_SUCCESS_PAGE_FORMAT': '/course/{course_id}/success'},
+            'features': {'ENABLE_MKTG_SITE': False},
+            'error_regexp': '.*MARKETING.*ENABLE_MKTG_SITE.*',
+        },
+        {
+            # Reason: Missing course details api format configuration
+            'mktg_urls': {'ROOT': 'https://omar'},
+            'features': {'ENABLE_MKTG_SITE': True},
+            'error_regexp': '.*MARKETING.*COURSE_SUCCESS_PAGE_FORMAT.*',
+        },
+        {
+            # Reason: Missing MKTG_URL['ROOT']
+            'mktg_urls': {'COURSE_SUCCESS_PAGE_FORMAT': '/api/{course_id}/'},
+            'features': {'ENABLE_MKTG_SITE': True},
+            'error_regexp': '.*MARKETING.*ROOT.*',
+        },
+        {
+            # Reason: Missing `course_id` in the API.
+            'mktg_urls': {'ROOT': 'https://omar', 'COURSE_SUCCESS_PAGE_FORMAT': '/api/{course_key}/'},
+            'features': {'ENABLE_MKTG_SITE': True},
+            'error_regexp': '.*MARKETING.*course_id.*',
+        },
+    )
+    @patch.dict(settings.FEATURES, EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE=True)
+    def test_enabled_feature_but_invalid_configs(self, mktg_urls, features, error_regexp):
+        with patch.dict(settings.FEATURES, features):
+            with patch.object(settings, 'MKTG_URLS', mktg_urls):
+                with self.assertRaisesRegexp(Exception, error_regexp):
+                    edraak_helpers.is_marketing_course_success_page_enabled()
+
+    @patch.dict(settings.FEATURES, ENABLE_MKTG_SITE=True, EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE=True)
+    @patch.object(settings, 'MKTG_URLS', {
+        'ROOT': 'https://mktg.com',
+        'COURSE_SUCCESS_PAGE_FORMAT': '/course/{course_id}/success',
+    })
+    def test_enabled_feature_and_marketing(self):
+        """
+        Also test the URL helper.
+        """
+        self.assertTrue(edraak_helpers.is_marketing_course_success_page_enabled(), 'Should be enabled')
+        self.assertEqual(edraak_helpers.get_course_success_page_url('a/b/c'), 'https://mktg.com/course/a/b/c/success')

--- a/common/djangoapps/course_modes/views.py
+++ b/common/djangoapps/course_modes/views.py
@@ -20,6 +20,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from xmodule.modulestore.django import modulestore
 
 from lms.djangoapps.commerce.utils import EcommerceService
+from course_modes.edraak_helpers import get_course_success_page_url
 from course_modes.models import CourseMode
 from courseware.access import has_access
 from edxmako.shortcuts import render_to_response
@@ -104,7 +105,7 @@ class ChooseModeView(View):
         # in the "honor" track by this point, so we send the user
         # to the dashboard.
         if not CourseMode.has_verified_mode(modes):
-            return redirect(reverse('dashboard'))
+            return redirect(get_course_success_page_url(course_id))
 
         # If a user has already paid, redirect them to the dashboard.
         if is_active and (enrollment_mode in CourseMode.VERIFIED_MODES + [CourseMode.NO_ID_PROFESSIONAL_MODE]):
@@ -209,7 +210,7 @@ class ChooseModeView(View):
 
         if requested_mode == 'honor':
             CourseEnrollment.enroll(user, course_key, mode=requested_mode)
-            return redirect(reverse('dashboard'))
+            return redirect(get_course_success_page_url(course_id))
 
         mode_info = allowed_modes[requested_mode]
 


### PR DESCRIPTION
**Task:**
 - Tasks for are losers 😄.

### Related PRs:
 - Dogwood PR: https://github.com/Edraak/edx-platform/pull/128
 - Configuration PR: https://github.com/Edraak/configuration-secure/pull/5

**Hint:** This adds a new feature `EDRAAK_USE_MARKETING_COURSE_SUCCESS_PAGE=True`.