### PR TITLE
Allow Edraak subdomains to pass CSRF checks on edx-platform

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -476,7 +476,11 @@ MIDDLEWARE_CLASSES = [
     'openedx.core.djangoapps.header_control.middleware.HeaderControlMiddleware',
     'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+
+    # Replaced by Edraak to allow cross origin CSRF
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'openedx.core.djangoapps.cors_csrf.middleware.CrossDomainCsrfViewMiddleware',
+
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
     # Allows us to define redirects via Django admin

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -1263,7 +1263,10 @@ MIDDLEWARE_CLASSES = [
     'corsheaders.middleware.CorsMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CorsCSRFMiddleware',
     'openedx.core.djangoapps.cors_csrf.middleware.CsrfCrossDomainCookieMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+
+    # Replaced by Edraak to allow cross origin CSRF
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'openedx.core.djangoapps.cors_csrf.middleware.CrossDomainCsrfViewMiddleware',
 
     'splash.middleware.SplashMiddleware',
 

--- a/lms/envs/load_test.py
+++ b/lms/envs/load_test.py
@@ -11,7 +11,9 @@ from .aws import *
 # Disable CSRF for load testing
 EXCLUDE_CSRF = lambda elem: elem not in [
     'django.template.context_processors.csrf',
-    'django.middleware.csrf.CsrfViewMiddleware'
+    # Replaced by Edraak to allow cross origin CSRF
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    'openedx.core.djangoapps.cors_csrf.middleware.CrossDomainCsrfViewMiddleware',
 ]
 DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors'] = filter(
     EXCLUDE_CSRF, DEFAULT_TEMPLATE_ENGINE['OPTIONS']['context_processors']

--- a/openedx/core/djangoapps/cors_csrf/decorators.py
+++ b/openedx/core/djangoapps/cors_csrf/decorators.py
@@ -1,5 +1,7 @@
 """Decorators for cross-domain CSRF. """
+from django.utils.decorators import decorator_from_middleware
 from django.views.decorators.csrf import ensure_csrf_cookie
+from .middleware import CrossDomainCsrfViewMiddleware
 
 
 def ensure_csrf_cookie_cross_domain(func):
@@ -26,3 +28,12 @@ def ensure_csrf_cookie_cross_domain(func):
         # CSRF cookie gets set.
         return ensure_csrf_cookie(func)(*args, **kwargs)
     return _inner
+
+
+csrf_protect = decorator_from_middleware(CrossDomainCsrfViewMiddleware)
+csrf_protect.__name__ = "csrf_protect"
+csrf_protect.__doc__ = """
+This decorator adds CSRF protection in exactly the same way as
+CsrfViewMiddleware, but it can be used on a per view basis.  Using both, or
+using the decorator multiple times, is harmless and efficient.
+"""

--- a/openedx/core/djangoapps/cors_csrf/helpers.py
+++ b/openedx/core/djangoapps/cors_csrf/helpers.py
@@ -90,3 +90,16 @@ def skip_cross_domain_referer_check(request):
         yield
     finally:
         request.is_secure = is_secure_default
+
+
+def same_origin(url1, url2):
+    """
+    Checks if two URLs are 'same-origin'
+    """
+    p1, p2 = urlparse(url1), urlparse(url2)
+    try:
+        o1 = (p1.scheme, p1.hostname, p1.port or PROTOCOL_TO_PORT[p1.scheme])
+        o2 = (p2.scheme, p2.hostname, p2.port or PROTOCOL_TO_PORT[p2.scheme])
+        return o1 == o2
+    except (ValueError, KeyError):
+        return False

--- a/openedx/core/djangoapps/cors_csrf/middleware.py
+++ b/openedx/core/djangoapps/cors_csrf/middleware.py
@@ -46,31 +46,14 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
-from django.middleware.csrf import CsrfViewMiddleware
-
-from .helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check
-
+from django.middleware import csrf as django_csrf
+from .helpers import is_cross_domain_request_allowed, skip_cross_domain_referer_check, same_origin
+from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_text
 
 log = logging.getLogger(__name__)
 
-
-class CorsCSRFMiddleware(CsrfViewMiddleware):
-    """
-    Middleware for handling CSRF checks with CORS requests
-    """
-    def __init__(self):
-        """Disable the middleware if the feature flag is disabled. """
-        if not settings.FEATURES.get('ENABLE_CORS_HEADERS'):
-            raise MiddlewareNotUsed()
-
-    def process_view(self, request, callback, callback_args, callback_kwargs):
-        """Skip the usual CSRF referer check if this is an allowed cross-domain request. """
-        if not is_cross_domain_request_allowed(request):
-            log.debug("Could not disable CSRF middleware referer check for cross-domain request.")
-            return
-
-        with skip_cross_domain_referer_check(request):
-            return super(CorsCSRFMiddleware, self).process_view(request, callback, callback_args, callback_kwargs)
+REASON_BAD_REFERER = "Referer checking failed - %s does not match any trusted origins."
 
 
 class CsrfCrossDomainCookieMiddleware(object):
@@ -145,3 +128,120 @@ class CsrfCrossDomainCookieMiddleware(object):
             )
 
         return response
+
+
+class CrossDomainCsrfViewMiddleware(django_csrf.CsrfViewMiddleware):
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+
+        if getattr(request, 'csrf_processing_done', False):
+            return None
+
+        try:
+            csrf_token = django_csrf._sanitize_token(
+                request.COOKIES[settings.CSRF_COOKIE_NAME])
+            # Use same token next time
+            request.META['CSRF_COOKIE'] = csrf_token
+        except KeyError:
+            csrf_token = None
+            # Generate token and store it in the request, so it's
+            # available to the view.
+            request.META["CSRF_COOKIE"] = django_csrf._get_new_csrf_string()
+
+        # Wait until request.META["CSRF_COOKIE"] has been manipulated before
+        # bailing out, so that get_token still works
+        if getattr(callback, 'csrf_exempt', False):
+            return None
+
+        # Assume that anything not defined as 'safe' by RFC2616 needs protection
+        if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
+            if getattr(request, '_dont_enforce_csrf_checks', False):
+                # Mechanism to turn off CSRF checks for test suite.
+                # It comes after the creation of CSRF cookies, so that
+                # everything else continues to work exactly the same
+                # (e.g. cookies are sent, etc.), but before any
+                # branches that call reject().
+                return self._accept(request)
+
+            if request.is_secure():
+                # Suppose user visits http://example.com/
+                # An active network attacker (man-in-the-middle, MITM) sends a
+                # POST form that targets https://example.com/detonate-bomb/ and
+                # submits it via JavaScript.
+                #
+                # The attacker will need to provide a CSRF cookie and token, but
+                # that's no problem for a MITM and the session-independent
+                # nonce we're using. So the MITM can circumvent the CSRF
+                # protection. This is true for any HTTP connection, but anyone
+                # using HTTPS expects better! For this reason, for
+                # https://example.com/ we need additional protection that treats
+                # http://example.com/ as completely untrusted. Under HTTPS,
+                # Barth et al. found that the Referer header is missing for
+                # same-domain requests in only about 0.2% of cases or less, so
+                # we can use strict Referer checking.
+                referer = force_text(
+                    request.META.get('HTTP_REFERER'),
+                    strings_only=True,
+                    errors='replace'
+                )
+                if referer is None:
+                    return self._reject(request, django_csrf.REASON_NO_REFERER)
+
+                # Here we generate a list of all acceptable HTTP referers,
+                # including the current host since that has been validated
+                # upstream.
+                good_hosts = list(settings.CSRF_TRUSTED_ORIGINS)
+                # Note that request.get_host() includes the port.
+                good_hosts.append(request.get_host())
+                good_referers = ['https://{0}/'.format(host) for host in good_hosts]
+                if not any(same_origin(referer, host) for host in good_referers):
+                    reason = REASON_BAD_REFERER % referer
+                    return self._reject(request, reason)
+
+            if csrf_token is None:
+                # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
+                # and in this way we can avoid all CSRF attacks, including login
+                # CSRF.
+                return self._reject(request, django_csrf.REASON_NO_CSRF_COOKIE)
+
+            # Check non-cookie token for match.
+            request_csrf_token = ""
+            if request.method == "POST":
+                try:
+                    request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
+                except IOError:
+                    # Handle a broken connection before we've completed reading
+                    # the POST data. process_view shouldn't raise any
+                    # exceptions, so we'll ignore and serve the user a 403
+                    # (assuming they're still listening, which they probably
+                    # aren't because of the error).
+                    pass
+
+            if request_csrf_token == "":
+                # Fall back to X-CSRFToken, to make things easier for AJAX,
+                # and possible for PUT/DELETE.
+                request_csrf_token = request.META.get('HTTP_X_CSRFTOKEN', '')
+
+            if not constant_time_compare(request_csrf_token, csrf_token):
+                return self._reject(request, django_csrf.REASON_BAD_TOKEN)
+
+        return self._accept(request)
+
+
+class CorsCSRFMiddleware(CrossDomainCsrfViewMiddleware):
+    """
+    Middleware for handling CSRF checks with CORS requests
+    """
+    def __init__(self):
+        """Disable the middleware if the feature flag is disabled. """
+        if not settings.FEATURES.get('ENABLE_CORS_HEADERS'):
+            raise MiddlewareNotUsed()
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        """Skip the usual CSRF referer check if this is an allowed cross-domain request. """
+        if not is_cross_domain_request_allowed(request):
+            log.debug("Could not disable CSRF middleware referer check for cross-domain request.")
+            return
+
+        with skip_cross_domain_referer_check(request):
+            return super(CorsCSRFMiddleware, self).process_view(request, callback, callback_args, callback_kwargs)


### PR DESCRIPTION
This is (almost) a copy of one of https://github.com/Edraak/edx-platform/pull/359 commits: https://github.com/Edraak/edx-platform/pull/359/commits/eb90b323738cb4d1eb702825d8c78508223d6151
