### PR TITLE
Apply Marketing PRs

### DIFF
--- a/common/djangoapps/course_modes/edraak_helpers.py
+++ b/common/djangoapps/course_modes/edraak_helpers.py
@@ -1,6 +1,7 @@
 """ Edraak custom helper methods for CourseModes. """
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.utils.translation import get_language
 
 from edxmako.shortcuts import marketing_link
 
@@ -47,3 +48,25 @@ def get_course_success_page_url(course_id):
         return marketing_root_format.format(course_id=course_id)
     else:
         return reverse('dashboard')
+
+
+def get_progs_url(page):
+    lang = ''
+
+    if get_language() != 'ar':
+        lang = 'en/'
+
+    root = settings.PROGS_URLS['ROOT']
+
+    if root[-1:] != '/':
+        root += '/'
+
+    if page[:1] == '/':
+        page = page[-(len(page) - 1):]
+
+    url = "{root}{lang}{page}".format(
+        root=root,
+        lang=lang,
+        page=page)
+
+    return url

--- a/common/djangoapps/course_modes/helpers.py
+++ b/common/djangoapps/course_modes/helpers.py
@@ -1,9 +1,6 @@
 """ Helper methods for CourseModes. """
-from urlparse import urljoin
-from functools import reduce
-
 from django.conf import settings
-from django.utils.translation import get_language, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 from course_modes.models import CourseMode
 from student.helpers import VERIFY_STATUS_APPROVED, VERIFY_STATUS_NEED_TO_VERIFY, VERIFY_STATUS_SUBMITTED
@@ -12,18 +9,6 @@ DISPLAY_VERIFIED = "verified"
 DISPLAY_HONOR = "honor"
 DISPLAY_AUDIT = "audit"
 DISPLAY_PROFESSIONAL = "professional"
-
-
-def get_progs_url(page):
-    lang = ''
-
-    if get_language() != 'ar':
-        lang = 'en/'
-
-    root = settings.PROGS_URLS['ROOT']
-
-    url = reduce(urljoin, [root, lang, page])
-    return url
 
 
 def enrollment_mode_display(mode, verification_status, course_id):

--- a/common/djangoapps/course_modes/tests/test_edraak_helpers.py
+++ b/common/djangoapps/course_modes/tests/test_edraak_helpers.py
@@ -74,3 +74,18 @@ class HelpersTestCase(ModuleStoreTestCase):
         """
         self.assertTrue(edraak_helpers.is_marketing_course_success_page_enabled(), 'Should be enabled')
         self.assertEqual(edraak_helpers.get_course_success_page_url('a/b/c'), 'https://mktg.com/course/a/b/c/success')
+
+    def _test_get_progs_url(self, path):
+        with patch('course_modes.edraak_helpers.get_language', return_value='en'):
+            self.assertEqual(edraak_helpers.get_progs_url(path), 'https://progs.com/en/page_path')
+
+        with patch('course_modes.edraak_helpers.get_language', return_value='ar'):
+            self.assertEqual(edraak_helpers.get_progs_url(path), 'https://progs.com/page_path')
+
+    @ddt.data('/page_path', 'page_path')
+    def test_get_progs_url(self, path):
+        with patch.object(settings, 'PROGS_URLS', {'ROOT': 'https://progs.com/'}):
+            self._test_get_progs_url(path)
+
+        with patch.object(settings, 'PROGS_URLS', {'ROOT': 'https://progs.com'}):
+            self._test_get_progs_url(path)

--- a/common/djangoapps/student/helpers.py
+++ b/common/djangoapps/student/helpers.py
@@ -336,7 +336,7 @@ def get_next_url_for_progs_login_page(request, initial_mode):
         # be saved in the session as part of the pipeline state. That URL will take priority
         # over this one.
 
-    from course_modes.helpers import get_progs_url
+    from course_modes.edraak_helpers import get_progs_url
 
     auth_url = get_progs_url(initial_mode)
 

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -5,6 +5,7 @@ Course API Serializers.  Representing course catalog data
 import urllib
 
 from django.urls import reverse
+from django.utils.translation import get_language
 from rest_framework import serializers
 
 from openedx.core.djangoapps.models.course_details import CourseDetails
@@ -116,11 +117,14 @@ class CourseDetailMarketingSerializer(CourseSerializer):
 
         overridden['effort'] = marketing_data['effort']
         overridden['name'] = marketing_data['name']
-        overridden['short_description'] = marketing_data['short_description']
+        if get_language() == 'en':
+            overridden['short_description'] = marketing_data['short_description_en']
+        else:
+            overridden['short_description'] = marketing_data['short_description_ar']
         overridden['overview'] = marketing_data['overview'] or ''
         overridden['name_en'] = marketing_data['name_en']
         overridden['name_ar'] = marketing_data['name_ar']
-        
+
         if marketing_data.get('course_image'):
             overridden['media']['course_image']['uri'] = marketing_data['course_image']
 

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -112,7 +112,7 @@ class CourseDetailMarketingSerializer(CourseSerializer):
         overridden = {}
         overridden.update(original_serialized_data)
 
-        overridden['effort'] = marketing_data['estimated_effort']
+        overridden['effort'] = marketing_data['effort']
         overridden['name'] = marketing_data['name']
         overridden['short_description'] = marketing_data['short_description']
         overridden['overview'] = marketing_data['overview'] or ''

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -64,6 +64,8 @@ class CourseSerializer(serializers.Serializer):  # pylint: disable=abstract-meth
     id = serializers.CharField()  # pylint: disable=invalid-name
     media = _CourseApiMediaCollectionSerializer(source='*')
     name = serializers.CharField(source='display_name_with_default_escaped')
+    name_en = serializers.CharField(read_only=True)
+    name_ar = serializers.CharField(read_only=True)
     number = serializers.CharField(source='display_number_with_default')
     org = serializers.CharField(source='display_org_with_default')
     short_description = serializers.CharField()
@@ -116,7 +118,9 @@ class CourseDetailMarketingSerializer(CourseSerializer):
         overridden['name'] = marketing_data['name']
         overridden['short_description'] = marketing_data['short_description']
         overridden['overview'] = marketing_data['overview'] or ''
-
+        overridden['name_en'] = marketing_data['name_en']
+        overridden['name_ar'] = marketing_data['name_ar']
+        
         if marketing_data.get('course_image'):
             overridden['media']['course_image']['uri'] = marketing_data['course_image']
 

--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -115,7 +115,7 @@ class CourseDetailMarketingSerializer(CourseSerializer):
         overridden['effort'] = marketing_data['estimated_effort']
         overridden['name'] = marketing_data['name']
         overridden['short_description'] = marketing_data['short_description']
-        overridden['overview'] = marketing_data['overview']
+        overridden['overview'] = marketing_data['overview'] or ''
 
         if marketing_data.get('course_image'):
             overridden['media']['course_image']['uri'] = marketing_data['course_image']

--- a/lms/djangoapps/course_api/tests/test_edraak_customizations.py
+++ b/lms/djangoapps/course_api/tests/test_edraak_customizations.py
@@ -17,7 +17,7 @@ from course_api import helpers
 
 
 MARKETING_COURSE_FIXTURE = {
-    'estimated_effort': '3',
+    'effort': '3',
     'name': 'A Fancier edX Demo Course',
     'course_image': 'https://edx.org/image.png',
     'course_video': 'https://edx.org/image.mp4',
@@ -144,7 +144,7 @@ class MarketingSiteCourseDetailsTestCase(ModuleStoreTestCase):
         super(MarketingSiteCourseDetailsTestCase, self).setUp()
         self.course = CourseFactory.create(
             display_name='edx demo course',
-            estimated_effort='3',
+            effort='3',
             short_description='forgot to add it in LMS!',
         )
         self.view = CourseDetailView(course_id=unicode(self.course.id))

--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -421,10 +421,48 @@
                 },
 
                 saveSuccess: function() {
+                    // Edraak (google-analytics): Send event on registration success
+                    if (ga) {
+                        ga('send', 'event', {
+                            eventCategory: 'Registration',
+                            eventAction: 'Submit',
+                            eventLabel: 'Register',
+                            eventValue: 1,
+                            transport: 'beacon'
+                        });
+                    }
+
+                    if (fbq) {
+                      fbq('track', 'CompleteRegistration', {status: 'successful'});
+                    }
+
+                    if (snaptr) {
+                      snaptr('track', 'SIGN_UP', {success: 1});
+                    }
+
                     this.trigger('auth-complete');
                 },
 
                 saveError: function(error) {
+                    // Edraak (google-analytics): Send event on registration failure
+                    if (ga) {
+                        ga('send', 'event', {
+                            eventCategory: 'Registration',
+                            eventAction: 'Submit',
+                            eventLabel: 'Register',
+                            eventValue: 0,
+                            transport: 'beacon'
+                        });
+                    }
+
+                    if (fbq) {
+                      fbq('track', 'CompleteRegistration', {status: 'failed'});
+                    }
+
+                    if(snaptr) {
+                      snaptr('track', 'SIGN_UP', {success: 0});
+                    }
+
                     $(this.el).show(); // Show in case the form was hidden for auto-submission
                     this.errors = _.flatten(
                         _.map(


### PR DESCRIPTION
This is to applly some changes made by the following PRs:

https://github.com/Edraak/edx-platform/pull/309 Return an empty overview if the marketing doesn't have one
https://github.com/Edraak/edx-platform/pull/310 Fix Course Details API to match the new marketing API
https://github.com/Edraak/edx-platform/pull/314 serialize ar and en names with courses
https://github.com/Edraak/edx-platform/pull/336 Log register event to google analytics
https://github.com/Edraak/edx-platform/pull/339 Feature/salah/add pixel and snapchat
https://github.com/Edraak/edx-platform/pull/348 Updates the course detail api
https://github.com/Edraak/edx-platform/pull/350 Keep language choice when switching to progs