### PR TITLE
Fix duplicate (class) attribute in Edraak University Listing

### DIFF
--- a/lms/templates/edraak_university/instructor/list.html
+++ b/lms/templates/edraak_university/instructor/list.html
@@ -29,7 +29,7 @@
                         </tr>
                     </thead>
                     % for uni_id in object_list:
-                        <tr class="university-id-entry" class="${'conflicted' if uni_id.is_conflicted else ''}">
+                        <tr class="${'university-id-entry conflicted' if uni_id.is_conflicted else 'university-id-entry'}">
                             <td class="break">
                                 ${uni_id.university_id}
 

--- a/lms/templates/edraak_university/instructor/list.html
+++ b/lms/templates/edraak_university/instructor/list.html
@@ -29,7 +29,7 @@
                         </tr>
                     </thead>
                     % for uni_id in object_list:
-                        <tr class="${'university-id-entry conflicted' if uni_id.is_conflicted else 'university-id-entry'}">
+                        <tr class="university-id-entry ${'conflicted' if uni_id.is_conflicted else ''}">
                             <td class="break">
                                 ${uni_id.university_id}
 


### PR DESCRIPTION
Duplicate University IDs are not being highlighted in Edraak University app when listed. The reason is a duplicate `class` attribute in HTML template

-------------
Related to https://edraak.atlassian.net/browse/OU-271