### PR TITLE
Fix redirect in Edraak University app

### DIFF
--- a/lms/templates/edraak_university/university_id_success.html
+++ b/lms/templates/edraak_university/university_id_success.html
@@ -23,7 +23,7 @@
     </p>
 
     <p class="text-center">
-        <a href="${reverse('courseware', kwargs={'course_id': course.id})}">
+        <a href="${reverse('openedx.course_experience.course_home', kwargs={'course_id': course.id})}">
             <strong>${_('View the Course Content')}</strong>
         </a>
     </p>


### PR DESCRIPTION
In University app; after applying **University ID** in **University tab** ; a success page is displayed with a button labeled **View the Course Content** . Pressing this button should redirect to course home, not course's first unit

------------
Related to https://edraak.atlassian.net/browse/OU-273