### PR TITLE
No need for parentheses around Staff word

### DIFF
--- a/common/static/common/templates/discussion/post-user-display.underscore
+++ b/common/static/common/templates/discussion/post-user-display.underscore
@@ -3,7 +3,7 @@
     <% if (is_community_ta) { %>
     <span class="user-label-community-ta"><%- gettext("(Community TA)") %></span>
     <% } else if (is_staff) { %>
-    <span class="user-label-staff"><%- gettext("(Staff)") %></span>
+    <span class="user-label-staff"><%- gettext("Staff") %></span>
     <% } %>
 <% } else { %>
     <%- gettext('anonymous') %>


### PR DESCRIPTION
No need for parentheses around `Staff` label

-------------
Related to https://edraak.atlassian.net/browse/OU-299
Related to https://github.com/Edraak/edraak-2019-theme/pull/34
