### PR TITLE
Revert "Hack: Increase ip-ratelimit to 1000"

### DIFF
--- a/common/djangoapps/edraak_ratelimit/backends.py
+++ b/common/djangoapps/edraak_ratelimit/backends.py
@@ -19,7 +19,7 @@ class EdraakRateLimitMixin(RateLimitMixin):
 
     # Edraak (ratelimit): We're overriding the values to avoid patching ratelimit pip package itself.
     minutes = 5
-    requests = 1000  # Make the limit a little bit more permissive
+    requests = 100  # Make the limit a little bit more permissive
 
     def db_log_failed_attempt(self, request, username=None):
         """

--- a/common/djangoapps/edraak_ratelimit/tests.py
+++ b/common/djangoapps/edraak_ratelimit/tests.py
@@ -49,7 +49,7 @@ class SettingsTest(TestCase):
         self.assertEquals(EdraakRateLimitModelBackend.minutes, 5,
                           msg='Keep the same edX tests, and avoid over-querying the cache')
 
-        self.assertEquals(EdraakRateLimitModelBackend.requests, 1000,  # Edraak hack: make it 1000 to make sure the feature actually works.
+        self.assertEquals(EdraakRateLimitModelBackend.requests, 100,
                           msg='Increase the requests limit per 5 minutes, to avoid locking university students')
 
 


### PR DESCRIPTION
Reverts Edraak/edraak-platform#175 because it was merged by mistake before fixing failed tests