### PR TITLE
Make LMS more resilient to progs being down

### DIFF
--- a/cms/envs/aws.py
+++ b/cms/envs/aws.py
@@ -527,6 +527,9 @@ INSTALLED_APPS += ('edraak_specializations',)
 
 PROGS_URLS = ENV_TOKENS.get('PROGS_URLS', PROGS_URLS)
 
+# API Calls Timeout
+EDRAAK_PROGRAMS_API_TIMEOUT = ENV_TOKENS.get('EDRAAK_PROGRAMS_API_TIMEOUT', 3)
+
 ################ PUSH NOTIFICATIONS ###############
 
 PARSE_KEYS = AUTH_TOKENS.get("PARSE_KEYS", {})

--- a/cms/envs/test.py
+++ b/cms/envs/test.py
@@ -334,6 +334,8 @@ INSTALLED_APPS += ('edraak_specializations',)
 
 COUNTRIES_FIRST = []  # Turned off here to pass edx tests
 
+EDRAAK_PROGRAMS_API_TIMEOUT = 4
+
 ######### custom courses #########
 INSTALLED_APPS.append('openedx.core.djangoapps.ccxcon.apps.CCXConnectorConfig')
 FEATURES['CUSTOM_COURSES_EDX'] = True


### PR DESCRIPTION
Make lms more resilient to programs being down

* Set 3 seconds timeout for saving specialization slug (actually this is a CMS issue)

-------------
Related to https://edraak.atlassian.net/browse/OU-395