### PR TITLE
auth/ratelimit use email instead of user

### DIFF
--- a/common/djangoapps/edraak_ratelimit/tests.py
+++ b/common/djangoapps/edraak_ratelimit/tests.py
@@ -295,7 +295,7 @@ class EdraakRateLimitModelBackendTest(TestCase):
 
             with self.assertRaises(RateLimitException):
                 mock_request = FakeRequest(ip_address='240.1.3.4')
-                backend.authenticate(username='user1', password='dummy', request=mock_request)
+                backend.authenticate(email='email@edraak.org', password='dummy', request=mock_request)
 
             db_log_failed_attempt.assert_called_once_with(mock_request, 'user1')
 
@@ -311,7 +311,7 @@ class EdraakRateLimitModelBackendTest(TestCase):
             backend = EdraakRateLimitModelBackend()
 
             mock_request = FakeRequest(ip_address='240.1.3.4')
-            authenticated_user = backend.authenticate(username='user1', password='dummy', request=mock_request)
+            authenticated_user = backend.authenticate(email='email@edraak.org', password='dummy', request=mock_request)
 
             self.assertIs(expected_user, authenticated_user, 'Should authenticate the user')
 

--- a/common/djangoapps/student/views/login.py
+++ b/common/djangoapps/student/views/login.py
@@ -268,10 +268,10 @@ def _authenticate_first_party(request, post_data, unauthenticated_user):
     # If the user doesn't exist, we want to set the username to an invalid username so that authentication is guaranteed
     # to fail and we can take advantage of the ratelimited backend
     username = unauthenticated_user.username if unauthenticated_user else ""
-
+    email = unauthenticated_user.email
     try:
         return authenticate(
-            username=username,
+            email=email,
             password=post_data.get('password', None),
             request=request)
 
@@ -419,7 +419,7 @@ def verify_user_password(request):
     """
     try:
         _check_excessive_login_attempts(request.user)
-        user = authenticate(username=request.user.username, password=request.POST['password'], request=request)
+        user = authenticate(email=request.user.email, password=request.POST['password'], request=request)
         if user:
             if LoginFailures.is_feature_enabled():
                 LoginFailures.clear_lockout_counter(user)

--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -127,7 +127,7 @@ class Users(SysadminDashboardView):
             if euser is None:
                 continue
             try:
-                testuser = authenticate(username=euser.username, password=epass)
+                testuser = authenticate(email=euser.email, password=epass)
             except (TypeError, PermissionDenied, AttributeError) as err:
                 # Translators: This message means that the user could not be authenticated (that is, we could
                 # not log them in for some reason - maybe they don't have permission, or their password was wrong)

--- a/openedx/core/djangoapps/external_auth/views.py
+++ b/openedx/core/djangoapps/external_auth/views.py
@@ -214,7 +214,7 @@ def _external_login_or_signup(request,
         else:
             AUDIT_LOG.info(u'Linked user "{0}" logged in via SSL certificate'.format(user.email))
     else:
-        user = authenticate(username=uname, password=eamap.internal_password, request=request)
+        user = authenticate(email=uname, password=eamap.internal_password, request=request)
 
     if user is None:
         # we want to log the failure, but don't want to log the password attempted:
@@ -866,7 +866,7 @@ def provider_login(request):
         username = user.username
         password = request.POST.get('password', None)
         try:
-            user = authenticate(username=username, password=password, request=request)
+            user = authenticate(email=user.email, password=password, request=request)
         except RateLimitException:
             AUDIT_LOG.warning(u'OpenID - Too many failed login attempts.')
             return HttpResponseRedirect(openid_request_url)

--- a/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
+++ b/openedx/core/djangoapps/oauth_dispatch/dot_overrides/validators.py
@@ -37,8 +37,7 @@ class EdxRateLimitedAllowAllUsersModelBackend(RateLimitMixin, UserModelBackend):
 
     See: https://openedx.atlassian.net/browse/TNL-4516
     """
-    pass
-
+    username_key = 'email'
 
 class EdxOAuth2Validator(OAuth2Validator):
     """
@@ -65,7 +64,7 @@ class EdxOAuth2Validator(OAuth2Validator):
         by username or email
         """
 
-        authenticated_user = authenticate(username=username, password=password)
+        authenticated_user = authenticate(email=username, password=password)
         if authenticated_user is None:
             UserModel = get_user_model()  # pylint: disable=invalid-name
             try:
@@ -73,7 +72,7 @@ class EdxOAuth2Validator(OAuth2Validator):
             except UserModel.DoesNotExist:
                 authenticated_user = None
             else:
-                authenticated_user = authenticate(username=email_user.username, password=password)
+                authenticated_user = authenticate(email=email_user.email, password=password, )
         return authenticated_user
 
     def save_bearer_token(self, token, request, *args, **kwargs):

--- a/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
+++ b/openedx/core/djangoapps/oauth_dispatch/tests/test_dot_overrides.py
@@ -37,15 +37,8 @@ class AuthenticateTestCase(TestCase):
         )
         self.validator = EdxOAuth2Validator()
 
-    def test_authenticate_with_username(self):
-        user = self.validator._authenticate(username='darkhelmet', password='12345')
-        self.assertEqual(
-            self.user,
-            user
-        )
-
     def test_authenticate_with_email(self):
-        user = self.validator._authenticate(username='darkhelmet@spaceball_one.org', password='12345')
+        user = self.validator._authenticate(email='darkhelmet@spaceball_one.org', password='12345')
         self.assertEqual(
             self.user,
             user

--- a/openedx/core/djangoapps/user_api/accounts/views.py
+++ b/openedx/core/djangoapps/user_api/accounts/views.py
@@ -484,7 +484,7 @@ class DeactivateLogoutView(APIView):
         """
         try:
             self._check_excessive_login_attempts(request.user)
-            user = authenticate(username=request.user.username, password=request.POST['password'], request=request)
+            user = authenticate(email=request.user.email, password=request.POST['password'], request=request)
             if user:
                 if LoginFailures.is_feature_enabled():
                     LoginFailures.clear_lockout_counter(user)

--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -50,7 +50,7 @@ django-mysql
 django-oauth-toolkit==0.12.0
 django-pyfs
 django-ratelimit
-django-ratelimit-backend==1.1.1
+django-ratelimit-backend==1.2
 django-require
 django-rest-swagger                 # API documentation
 django-sekizai

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -87,7 +87,7 @@ django-mysql==2.3.0
 django-oauth-toolkit==0.12.0
 django-object-actions==0.10.0  # via edx-enterprise
 django-pyfs==2.0
-django-ratelimit-backend==1.1.1
+django-ratelimit-backend==1.2
 django-ratelimit==1.1.0
 django-require==1.0.11
 django-rest-swagger==2.2.0

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -107,7 +107,7 @@ django-mysql==2.3.0
 django-oauth-toolkit==0.12.0
 django-object-actions==0.10.0
 django-pyfs==2.0
-django-ratelimit-backend==1.1.1
+django-ratelimit-backend==1.2
 django-ratelimit==1.1.0
 django-require==1.0.11
 django-rest-swagger==2.2.0

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -103,7 +103,7 @@ django-mysql==2.3.0
 django-oauth-toolkit==0.12.0
 django-object-actions==0.10.0
 django-pyfs==2.0
-django-ratelimit-backend==1.1.1
+django-ratelimit-backend==1.2
 django-ratelimit==1.1.0
 django-require==1.0.11
 django-rest-swagger==2.2.0


### PR DESCRIPTION
When Arabic username trying to login to mobile, validator.py call authenticate (sending username), calls the ratelimitauthbackend which fails (unicode error)

Version 1.2 they added support for different username key https://django-ratelimit-backend.readthedocs.io/en/latest/

Reset of the changes just switching to using email instead of username for auth
