### PR TITLE
Instructor dashboard fixes: patch for PR#222

### DIFF
--- a/lms/static/js/instructor_dashboard/util.js
+++ b/lms/static/js/instructor_dashboard/util.js
@@ -357,15 +357,17 @@
                     ths, arguments
                 );
             };
-            this.$running_tasks_section = findAndAssert(this.$section, '.running-tasks-section');
-            this.$table_running_tasks = findAndAssert(this.$section, '.running-tasks-table');
-            this.$no_tasks_message = findAndAssert(this.$section, '.no-pending-tasks-message');
-            if (this.$table_running_tasks.length) {
-                TASK_LIST_POLL_INTERVAL = 20000;
-                this.reload_running_tasks_list();
-                this.task_poller = new IntervalManager(TASK_LIST_POLL_INTERVAL, function() {
-                    return ths.reload_running_tasks_list();
-                });
+            if (this.$section.find('.running-tasks-container').length) {
+                this.$running_tasks_section = findAndAssert(this.$section, '.running-tasks-section');
+                this.$table_running_tasks = findAndAssert(this.$section, '.running-tasks-table');
+                this.$no_tasks_message = findAndAssert(this.$section, '.no-pending-tasks-message');
+                if (this.$table_running_tasks.length) {
+                    TASK_LIST_POLL_INTERVAL = 20000;
+                    this.reload_running_tasks_list();
+                    this.task_poller = new IntervalManager(TASK_LIST_POLL_INTERVAL, function () {
+                        return ths.reload_running_tasks_list();
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Continue with one more issue related to instructor dashboard as in https://github.com/Edraak/edraak-platform/pull/222

3- Running tasks containers are not available when certain settings flags are off (example: `ENABLE_INSTRUCTOR_BACKGROUND_TASKS`). This is causing `Uncaught Failed Element Selection` error to keep logged
