### PR TITLE
New API to allow staff user to deactivate users

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/tests/retirement_helpers.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/retirement_helpers.py
@@ -16,6 +16,7 @@ from openedx.core.djangoapps.user_api.models import (
 from student.models import (
     get_retired_username_by_username,
     get_retired_email_by_email,
+    Registration,
 )
 from student.tests.factories import UserFactory
 
@@ -156,6 +157,27 @@ class RetirementTestCase(TestCase):
 
     def _get_dead_end_states(self):
         return [state for state in RetirementState.objects.filter(is_dead_end_state=True)]
+
+
+class RetirementTestUserMixin(object):
+    """
+    Create a test user for retirement
+    """
+    def setUp(self):
+        self.test_password = 'password'
+        self.test_user = UserFactory(password=self.test_password)
+        UserSocialAuth.objects.create(
+            user=self.test_user,
+            provider='some_provider_name',
+            uid='xyz@gmail.com'
+        )
+        UserSocialAuth.objects.create(
+            user=self.test_user,
+            provider='some_other_provider_name',
+            uid='xyz@gmail.com'
+        )
+
+        Registration().register(self.test_user)
 
 
 def fake_completed_retirement(user):

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -13,6 +13,7 @@ from .accounts.views import (
     AccountRetirementStatusView,
     AccountRetirementView,
     AccountViewSet,
+    DeactivateBySuperuserView,
     DeactivateLogoutView,
     LMSAccountRetirementView
 )
@@ -98,6 +99,11 @@ urlpatterns = [
         r'^v1/accounts/deactivate_logout/$',
         DeactivateLogoutView.as_view(),
         name='deactivate_logout'
+    ),
+    url(
+        r'^v1/accounts/deactivate/$',
+        DeactivateBySuperuserView.as_view(),
+        name='deactivate'
     ),
     url(
         r'^v1/accounts/{}/verification_status/$'.format(settings.USERNAME_PATTERN),


### PR DESCRIPTION
New API to allow a staff user to deactivate another user.
* Endpoint: `POST /api/user/v1/accounts/deactivate/`
* Parameters: `{'username': '<username to deactivate>'}`
* Returns `HTTP_403_FORBIDDEN` if caller user is authenticated or does not have `CanRetireUser` permission
* Returns `HTTP_404_NOT_FOUND` if the user in the parameter does not exist
* Returns `HTTP_403_FORBIDDEN` if caller user is about to deactivate a superuser, staff user, or retirement worker user `RETIREMENT_SERVICE_WORKER_USERNAME`

----------------
Related to https://edraak.atlassian.net/browse/OU-441