### PR TITLE
Fix infinte redirecting

### DIFF
--- a/lms/djangoapps/course_api/serializers.py
+++ b/lms/djangoapps/course_api/serializers.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import get_language
 from rest_framework import serializers
 
+from course_api.helpers import get_marketing_data, is_marketing_api_enabled
 from openedx.core.djangoapps.models.course_details import CourseDetails
 from openedx.core.lib.api.fields import AbsoluteURLField
 
@@ -132,6 +133,16 @@ class CourseDetailMarketingSerializer(CourseSerializer):
 
     This allows reuse of the marketing site data, as opposed to duplicating them in the LMS.
     """
+    @staticmethod
+    def update_marketing_context(context, course_key):
+        if is_marketing_api_enabled():
+            lang = 'en'
+            if context.get('request') and hasattr(context['request'], 'LANGUAGE_CODE'):
+                lang = context['request'].LANGUAGE_CODE
+            context['marketing_data'] = get_marketing_data(
+                course_key=course_key,
+                language=lang,
+            )
 
     def get_data_with_marketing_overrides(self, original_serialized_data):
         marketing_data = self.context.get('marketing_data')

--- a/lms/djangoapps/course_api/views.py
+++ b/lms/djangoapps/course_api/views.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.throttling import UserRateThrottle
 
-from course_api.helpers import get_marketing_data, is_marketing_api_enabled
+from course_api.helpers import is_marketing_api_enabled
 from edx_rest_framework_extensions.paginators import NamespacedPageNumberPagination
 from openedx.core.lib.api.view_utils import DeveloperErrorViewMixin, view_auth_classes
 
@@ -18,6 +18,7 @@ from .forms import CourseDetailGetForm, CourseListGetForm
 from .serializers import CourseDetailSerializer, CourseDetailMarketingSerializer, CourseSerializer
 import branding
 
+
 def get_all_courses(org=None, filter_=None, exclude_ended=None):
     """
     Returns a list of courses available, sorted by course.number and optionally
@@ -25,6 +26,7 @@ def get_all_courses(org=None, filter_=None, exclude_ended=None):
     """
     courses = branding.get_visible_courses(org=org, filter_=filter_, exclude_ended=exclude_ended)
     return courses
+
 
 @view_auth_classes(is_authenticated=False)
 class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
@@ -122,9 +124,9 @@ class CourseDetailView(DeveloperErrorViewMixin, RetrieveAPIView):
     def get_serializer_context(self):
         context = super(CourseDetailView, self).get_serializer_context()
         if is_marketing_api_enabled():
-            context['marketing_data'] = get_marketing_data(
-                course_key=self.kwargs['course_key_string'],
-                language=self.request.LANGUAGE_CODE,
+            CourseDetailMarketingSerializer.update_marketing_context(
+                context=context,
+                course_key=self.kwargs['course_key_string']
             )
         calculate_completion = self.request.GET.get('calculate_completion', 'false') in ['true', 'True']
         context['calculate_completion'] = calculate_completion

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -30,7 +30,9 @@ from lms.djangoapps.courseware.courseware_access_exception import CoursewareAcce
 from lms.djangoapps.courseware.exceptions import CourseAccessRedirect
 from opaque_keys.edx.keys import UsageKey
 from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
+from openedx.core.djangoapps.request_cache import get_request_or_stub
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
+from openedx.features.course_experience import course_home_url_name
 from path import Path as path
 from six import text_type
 from static_replace import replace_static_urls
@@ -155,6 +157,10 @@ def check_course_access(course, user, action, check_if_enrolled=False, check_sur
     if check_if_enrolled:
         # If the user is not enrolled, redirect them to the about page
         if not CourseEnrollment.is_enrolled(user, course.id):
+            current_request = get_request_or_stub()
+            if current_request:
+                if current_request.path == reverse(course_home_url_name(course.id), args=[text_type(course.id)]):
+                    return
             raise CourseAccessRedirect(reverse('about_course', args=[unicode(course.id)]))
 
     # Redirect if the user must answer a survey before entering the course.


### PR DESCRIPTION
### Description

the QA did the following scenario

1 - enroll in a specialization 
2 - went to a course under the specialization
3 - and opened the page for that course for example `/courses/course-v1:ORG1ORG1+123+2020_T1/course/` and kept it open
3 - in another tab she went to the dashboard and un-enrolled from the specialization
4 - she got back to the course page and refreshed the page and that leads to the course view and the about page to keep redirecting to each other 

and this scenario will lead to this 

<img width="1428" alt="Screen Shot 2020-11-16 at 1 10 30 PM" src="https://user-images.githubusercontent.com/38977667/99245952-25df2900-280d-11eb-801c-30654ac084ca.png">


in `lms/djangoapps/courseware/views/views.py` function `course_about`

these lines will redirect the user to the course home (eg: `/courses/course-v1:ORG1ORG1+123+2020_T1/course/` )

```py
if configuration_helpers.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
      return redirect(reverse(course_home_url_name(course.id), args=[text_type(course.id)]))
```

and this block in  `lms/djangoapps/courseware/courses.py`

```py
if check_if_enrolled:
   # If the user is not enrolled, redirect them to the about page
   if not CourseEnrollment.is_enrolled(user, course.id):
       raise CourseAccessRedirect(reverse('about_course', args=[unicode(course.id)]))
```

will redirect the user into the `about` page and this will keep going forever

do you think the solution in this PR is valid?


Jira card 
https://edraak.atlassian.net/browse/EC2020-716