### PR TITLE
Quote Course Image URLs in Certificate email

### DIFF
--- a/common/templates/student/edx_ace/edraakcertificatecongrats/email/body.html
+++ b/common/templates/student/edx_ace/edraakcertificatecongrats/email/body.html
@@ -36,9 +36,9 @@
             <td style="width: {{ recommendations_width }}%">
                 <a href="{{ course_info.course_url }}">
                     <img
-                            src="{{ course_info.course_img }}"
-                            alt="{{ course_info.course_name }}"
-                            style="width: 78%; height: auto; margin-left: 10%; margin-right: 10%"
+                        src="{{ course_info.course_img }}"
+                        alt="{{ course_info.course_name }}"
+                        style="width: 78%; height: auto; margin-left: 10%; margin-right: 10%"
                     >
                 </a>
             </td>
@@ -47,7 +47,11 @@
     <tr>
         {% for course_info2 in recommendations %}
             <td style="width: {{ recommendations_width }}%">
-                <h3 style="text-align: center">{{ course_info2.course_name }}</h3>
+                <a href="{{ course_info2.course_url }}">
+                    <h3 style="text-align: center; width: 78%; height: auto; margin-left: 10%; margin-right: 10%">
+                        {{ course_info2.course_name }}
+                    </h3>
+                </a>
             </td>
         {% endfor %}
     </tr>


### PR DESCRIPTION
* Quote URLs before adding them to Certificate email: Recommender is returning unquoted URLs for course-image. Google safe-mail or (or maybe edx-ace itself) is replacing spaces with a plus sign, which damages the URL
* Convert course name in Certificate email to a hypertext
* Fix course name width

---------------------
Related to https://edraak.atlassian.net/browse/OU-522
Related to https://edraak.atlassian.net/browse/OU-523
Related to https://github.com/Edraak/edraak-platform/pull/248