### PR TITLE
[PRODDEV-82] Use 'signed_sessionid' as the session cookie name in development

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -615,10 +615,14 @@ CODE_JAIL = {
 ############################ DJANGO_BUILTINS ################################
 # Change DEBUG in your environment settings files, not here
 DEBUG = False
+
+# See comments in the auth_provider configuration.
 SESSION_COOKIE_SECURE = False
 SESSION_SAVE_EVERY_REQUEST = False
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
+# In production, redefined by aws.py
+SESSION_COOKIE_NAME = 'signed_sessionid'
 
 # Site info
 SITE_NAME = "localhost:8001"


### PR DESCRIPTION
### Description

It's already used in production and on staging, but we need to align all
session cookie names to make sure "progs" and "mktg" services can detect when
a user is not logged in on the legacy platform.

Ref: https://edraak.atlassian.net/browse/PRODDEV-82?focusedCommentId=17879

